### PR TITLE
Add support for InternalsVisibleToSuffix

### DIFF
--- a/build/InternalsVisibleTo.MSBuild.targets
+++ b/build/InternalsVisibleTo.MSBuild.targets
@@ -10,6 +10,12 @@
         <_Parameter1>%(InternalsVisibleTo.Identity)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
+    
+    <ItemGroup Condition="@(InternalsVisibleToSuffix->Count()) &gt; 0">
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>$(AssemblyName)%(InternalsVisibleToSuffix.Identity)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
Allows a new way to declare `InternalsVisibleTo` using a suffix

````
<ItemGroup>
  <InternalsVisibleToSuffix Include=".Tests" /> <!-- [assembly: InternalsVisibleTo("ClassLibrary1.Tests")] -->   
</ItemGroup>
````