### PR TITLE
Add type name to the assembly attribute items

### DIFF
--- a/build/InternalsVisibleTo.MSBuild.targets
+++ b/build/InternalsVisibleTo.MSBuild.targets
@@ -9,12 +9,14 @@
     <ItemGroup Condition="@(InternalsVisibleTo->Count()) &gt; 0">
       <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
         <_Parameter1>%(InternalsVisibleTo.Identity)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
       </AssemblyAttribute>
     </ItemGroup>
     
     <ItemGroup Condition="@(InternalsVisibleToSuffix->Count()) &gt; 0">
       <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
         <_Parameter1>$(AssemblyName)%(InternalsVisibleToSuffix.Identity)</_Parameter1>
+        <_Parameter1_TypeName>System.String</_Parameter1_TypeName>
       </AssemblyAttribute>
     </ItemGroup>
 


### PR DESCRIPTION
this specifies the type of the parameter in the assembly
stops the compiler emitting `Could not infer the type of parameter "#1" because the attribute type is unknown. The value will be treated as a string.`